### PR TITLE
Bump Canvas version

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
         "underscore": "=1.4.2"
     },
     "optionalDependencies": {
-        "canvas": "=1.0.1"
+        "canvas": "=1.1.1"
     },
     "devDependencies": {
         "assetgraph": "=1.2.3",


### PR DESCRIPTION
Canvas version 1.1.1 adds support for Giflib 5 ([relevant commit](https://github.com/LearnBoost/node-canvas/commit/a0632275c53d0ed4811a96fb7bf12ebd5668f289)) which is the version available on some platforms, such as Arch Linux for instance.
Bumping the version of Canvas will make it possible to use assetgraph-sprite on those platforms without going through the trouble of installing an old version of the library.
